### PR TITLE
Update list retrieval api to include emails mapping

### DIFF
--- a/contact.go
+++ b/contact.go
@@ -49,9 +49,10 @@ type Contact struct {
 }
 
 type FetchContactOptions struct {
-	ID        uuid.UUID
-	Email     Email
-	Reference Reference
+	ID          uuid.UUID
+	Email       Email
+	Reference   Reference
+	WorkspaceID uuid.UUID
 }
 
 type ContactRepository interface {

--- a/contact_list.go
+++ b/contact_list.go
@@ -60,5 +60,15 @@ type ContactListRepository interface {
 	Delete(context.Context, *ContactList) error
 	Update(context.Context, *ContactList) error
 	Add(context.Context, *ContactListMapping) error
-	List(context.Context, *ContactListOptions) ([]ContactList, []ContactListMapping, error)
+	List(context.Context, *ContactListOptions) ([]ContactList, []ContactListMappingWithContact, error)
+}
+
+type ContactListMappingWithContact struct {
+	ID        uuid.UUID `json:"id,omitempty"`
+	ListID    uuid.UUID `json:"list_id,omitempty"`
+	ContactID uuid.UUID `json:"contact_id,omitempty"`
+	Reference string    `json:"reference,omitempty"`
+
+	// Contact fields
+	Email string `json:"email,omitempty"`
 }

--- a/contact_list.go
+++ b/contact_list.go
@@ -49,11 +49,16 @@ type FetchContactListOptions struct {
 	WorkspaceID uuid.UUID
 }
 
+type ContactListOptions struct {
+	WorkspaceID   uuid.UUID
+	IncludeEmails bool
+}
+
 type ContactListRepository interface {
 	Create(context.Context, *ContactList) error
 	Get(context.Context, FetchContactListOptions) (*ContactList, error)
 	Delete(context.Context, *ContactList) error
 	Update(context.Context, *ContactList) error
 	Add(context.Context, *ContactListMapping) error
-	List(context.Context, uuid.UUID) ([]ContactList, error)
+	List(context.Context, *ContactListOptions) ([]ContactList, []ContactListMapping, error)
 }

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -133,6 +133,27 @@
 				},
 				"type": "object"
 			},
+			"malak.ContactListMappingWithContact": {
+				"properties": {
+					"contact_id": {
+						"type": "string"
+					},
+					"email": {
+						"description": "Contact fields",
+						"type": "string"
+					},
+					"id": {
+						"type": "string"
+					},
+					"list_id": {
+						"type": "string"
+					},
+					"reference": {
+						"type": "string"
+					}
+				},
+				"type": "object"
+			},
 			"malak.CustomContactMetadata": {
 				"additionalProperties": {
 					"type": "string"
@@ -341,9 +362,6 @@
 			},
 			"server.addContactToListRequest": {
 				"properties": {
-					"contactList": {
-						"type": "string"
-					},
 					"reference": {
 						"type": "string"
 					}
@@ -491,7 +509,7 @@
 								},
 								"mappings": {
 									"items": {
-										"$ref": "#/components/schemas/malak.ContactListMapping"
+										"$ref": "#/components/schemas/malak.ContactListMappingWithContact"
 									},
 									"type": "array"
 								}

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -485,7 +485,22 @@
 				"properties": {
 					"lists": {
 						"items": {
-							"$ref": "#/components/schemas/malak.ContactList"
+							"properties": {
+								"list": {
+									"$ref": "#/components/schemas/malak.ContactList"
+								},
+								"mappings": {
+									"items": {
+										"$ref": "#/components/schemas/malak.ContactListMapping"
+									},
+									"type": "array"
+								}
+							},
+							"required": [
+								"list",
+								"mappings"
+							],
+							"type": "object"
 						},
 						"type": "array"
 					},
@@ -494,6 +509,7 @@
 					}
 				},
 				"required": [
+					"lists",
 					"message"
 				],
 				"type": "object"
@@ -798,6 +814,16 @@
 		"/contacts/lists": {
 			"get": {
 				"operationId": "fetchContactLists",
+				"parameters": [
+					{
+						"description": "show emails inside the list",
+						"in": "query",
+						"name": "include_emails",
+						"schema": {
+							"type": "boolean"
+						}
+					}
+				],
 				"responses": {
 					"200": {
 						"content": {

--- a/errors.go
+++ b/errors.go
@@ -1,5 +1,11 @@
 package malak
 
+import "strings"
+
 type MalakError string
 
 func (m MalakError) Error() string { return string(m) }
+
+func IsDuplicateUniqueError(e error) bool {
+	return strings.Contains(e.Error(), "duplicate key value violates unique constraint")
+}

--- a/errors.go
+++ b/errors.go
@@ -7,5 +7,9 @@ type MalakError string
 func (m MalakError) Error() string { return string(m) }
 
 func IsDuplicateUniqueError(e error) bool {
+	if e == nil {
+		return false
+	}
+
 	return strings.Contains(e.Error(), "duplicate key value violates unique constraint")
 }

--- a/internal/datastore/postgres/contact.go
+++ b/internal/datastore/postgres/contact.go
@@ -69,7 +69,8 @@ func (o *contactRepo) Get(ctx context.Context,
 	ctx, cancelFn := withContext(ctx)
 	defer cancelFn()
 
-	q := o.inner.NewSelect()
+	q := o.inner.NewSelect().
+		Where("workspace_id = ?", opts.WorkspaceID)
 
 	if !util.IsStringEmpty(opts.Reference.String()) {
 		q = q.Where("reference = ?", opts.Reference.String())

--- a/internal/datastore/postgres/contact_list.go
+++ b/internal/datastore/postgres/contact_list.go
@@ -151,6 +151,10 @@ func (c *contactListRepo) Add(ctx context.Context,
 				Model(mapping).
 				Exec(ctx)
 
+			if malak.IsDuplicateUniqueError(err) {
+				return nil
+			}
+
 			return err
 		})
 }

--- a/internal/datastore/postgres/contact_list_test.go
+++ b/internal/datastore/postgres/contact_list_test.go
@@ -89,7 +89,10 @@ func TestContactList(t *testing.T) {
 
 	}
 
-	lists, err := contactRepo.List(context.Background(), uuid.MustParse("a4ae79a2-9b76-40d7-b5a1-661e60a02cb0"))
+	lists, _, err := contactRepo.List(context.Background(),
+		&malak.ContactListOptions{
+			WorkspaceID: uuid.MustParse("a4ae79a2-9b76-40d7-b5a1-661e60a02cb0"),
+		})
 	require.NoError(t, err)
 
 	require.Len(t, lists, 2)

--- a/internal/datastore/postgres/contact_list_test.go
+++ b/internal/datastore/postgres/contact_list_test.go
@@ -143,6 +143,14 @@ func TestContactList_Add(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, list.Title, newList.Title)
 
+	_, mappings, err := contactListRepo.List(context.Background(),
+		&malak.ContactListOptions{
+			WorkspaceID: uuid.MustParse("a4ae79a2-9b76-40d7-b5a1-661e60a02cb0"),
+		})
+	require.NoError(t, err)
+
+	require.Len(t, mappings, 0)
+
 	err = contactListRepo.Add(context.Background(), &malak.ContactListMapping{
 		ListID:    newList.ID,
 		ContactID: contact.ID,
@@ -150,4 +158,12 @@ func TestContactList_Add(t *testing.T) {
 		CreatedBy: user.ID,
 	})
 	require.NoError(t, err)
+
+	_, mappings, err = contactListRepo.List(context.Background(),
+		&malak.ContactListOptions{
+			WorkspaceID: uuid.MustParse("a4ae79a2-9b76-40d7-b5a1-661e60a02cb0"),
+		})
+	require.NoError(t, err)
+
+	require.Len(t, mappings, 1)
 }

--- a/internal/datastore/postgres/contact_test.go
+++ b/internal/datastore/postgres/contact_test.go
@@ -9,6 +9,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+var (
+	workspaceID = uuid.MustParse("c12da796-9362-4c70-b2cb-fc8a1eba2526")
+)
+
 func TestContact_Get(t *testing.T) {
 
 	client, teardownFunc := setupDatabase(t)
@@ -17,12 +21,14 @@ func TestContact_Get(t *testing.T) {
 	contactRepo := NewContactRepository(client)
 
 	_, err := contactRepo.Get(context.Background(), malak.FetchContactOptions{
-		Reference: "contact_kCoC286IR", // contacts.yml
+		Reference:   "contact_kCoC286IR", // contacts.yml
+		WorkspaceID: workspaceID,
 	})
 	require.NoError(t, err)
 
 	_, err = contactRepo.Get(context.Background(), malak.FetchContactOptions{
-		Reference: "contact_kCo",
+		Reference:   "contact_kCo",
+		WorkspaceID: workspaceID,
 	})
 	require.Error(t, err)
 	require.Equal(t, err, malak.ErrContactNotFound)

--- a/internal/datastore/postgres/migrations/20241113221847_unique_constraint_list_mappings.down.sql
+++ b/internal/datastore/postgres/migrations/20241113221847_unique_constraint_list_mappings.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE contact_list_mappings DROP CONSTRAINT unique_contact_list;

--- a/internal/datastore/postgres/migrations/20241113221847_unique_constraint_list_mappings.up.sql
+++ b/internal/datastore/postgres/migrations/20241113221847_unique_constraint_list_mappings.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE contact_list_mappings ADD CONSTRAINT unique_contact_list UNIQUE (contact_id, list_id);

--- a/internal/pkg/queue/watermill/watermill.go
+++ b/internal/pkg/queue/watermill/watermill.go
@@ -190,7 +190,8 @@ func (t *WatermillClient) sendPreviewEmail(msg *message.Message) error {
 	}
 
 	contact, err := t.contactRepo.Get(ctx, malak.FetchContactOptions{
-		Email: p.Email,
+		Email:       p.Email,
+		WorkspaceID: update.WorkspaceID,
 	})
 	if err != nil {
 		span.RecordError(err)

--- a/mocks/contact_list.go
+++ b/mocks/contact_list.go
@@ -99,11 +99,11 @@ func (mr *MockContactListRepositoryMockRecorder) Get(arg0, arg1 any) *gomock.Cal
 }
 
 // List mocks base method.
-func (m *MockContactListRepository) List(arg0 context.Context, arg1 *malak.ContactListOptions) ([]malak.ContactList, []malak.ContactListMapping, error) {
+func (m *MockContactListRepository) List(arg0 context.Context, arg1 *malak.ContactListOptions) ([]malak.ContactList, []malak.ContactListMappingWithContact, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "List", arg0, arg1)
 	ret0, _ := ret[0].([]malak.ContactList)
-	ret1, _ := ret[1].([]malak.ContactListMapping)
+	ret1, _ := ret[1].([]malak.ContactListMappingWithContact)
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2
 }

--- a/mocks/contact_list.go
+++ b/mocks/contact_list.go
@@ -14,7 +14,6 @@ import (
 	reflect "reflect"
 
 	malak "github.com/ayinke-llc/malak"
-	uuid "github.com/google/uuid"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -100,12 +99,13 @@ func (mr *MockContactListRepositoryMockRecorder) Get(arg0, arg1 any) *gomock.Cal
 }
 
 // List mocks base method.
-func (m *MockContactListRepository) List(arg0 context.Context, arg1 uuid.UUID) ([]malak.ContactList, error) {
+func (m *MockContactListRepository) List(arg0 context.Context, arg1 *malak.ContactListOptions) ([]malak.ContactList, []malak.ContactListMapping, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "List", arg0, arg1)
 	ret0, _ := ret[0].([]malak.ContactList)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret1, _ := ret[1].([]malak.ContactListMapping)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
 }
 
 // List indicates an expected call of List.

--- a/server/contact.go
+++ b/server/contact.go
@@ -433,7 +433,8 @@ func (c *contactHandler) addUserToContactList(
 		zap.String("list_reference", reference))
 
 	contact, err := c.contactRepo.Get(ctx, malak.FetchContactOptions{
-		Reference: req.Reference,
+		Reference:   req.Reference,
+		WorkspaceID: getWorkspaceFromContext(ctx).ID,
 	})
 	if errors.Is(err, malak.ErrContactNotFound) {
 		return newAPIStatus(http.StatusNotFound, err.Error()), StatusFailed

--- a/server/contact.go
+++ b/server/contact.go
@@ -234,21 +234,20 @@ func (c *contactHandler) fetchContactLists(
 			"an error occurred while fetching contact lists"), StatusFailed
 	}
 
-	// keep this relatively simple for now
-	mappingsByListID := make(map[uuid.UUID][]malak.ContactListMapping)
+	mappingsByListID := make(map[uuid.UUID][]malak.ContactListMappingWithContact)
 	for _, mapping := range mappings {
 		mappingsByListID[mapping.ListID] = append(mappingsByListID[mapping.ListID], mapping)
 	}
 
 	responseLists := []struct {
-		List     malak.ContactList          "json:\"list,omitempty\" validate:\"required\""
-		Mappings []malak.ContactListMapping "json:\"mappings,omitempty\" validate:\"required\""
+		List     malak.ContactList                     "json:\"list,omitempty\" validate:\"required\""
+		Mappings []malak.ContactListMappingWithContact "json:\"mappings,omitempty\" validate:\"required\""
 	}{}
 
 	for _, v := range list {
 		responseLists = append(responseLists, struct {
-			List     malak.ContactList          "json:\"list,omitempty\" validate:\"required\""
-			Mappings []malak.ContactListMapping "json:\"mappings,omitempty\" validate:\"required\""
+			List     malak.ContactList                     "json:\"list,omitempty\" validate:\"required\""
+			Mappings []malak.ContactListMappingWithContact "json:\"mappings,omitempty\" validate:\"required\""
 		}{
 			List:     v,
 			Mappings: mappingsByListID[v.ID],

--- a/server/contact.go
+++ b/server/contact.go
@@ -206,6 +206,7 @@ func (c *contactHandler) createContactList(
 // @id fetchContactLists
 // @Accept  json
 // @Produce  json
+// @Param include_emails query boolean false "show emails inside the list"
 // @Success 200 {object} fetchContactListsResponse
 // @Failure 400 {object} APIStatus
 // @Failure 401 {object} APIStatus
@@ -221,7 +222,10 @@ func (c *contactHandler) fetchContactLists(
 
 	logger.Debug("listing all contact lists in this workspace")
 
-	list, err := c.contactListRepo.List(ctx, getWorkspaceFromContext(ctx).ID)
+	list, mappings, err := c.contactListRepo.List(ctx, &malak.ContactListOptions{
+		WorkspaceID:   getWorkspaceFromContext(ctx).ID,
+		IncludeEmails: r.URL.Query().Has("include_emails"),
+	})
 	if err != nil {
 		logger.
 			Error("an error occurred while listing contact lists", zap.Error(err))
@@ -230,9 +234,30 @@ func (c *contactHandler) fetchContactLists(
 			"an error occurred while fetching contact lists"), StatusFailed
 	}
 
+	// keep this relatively simple for now
+	mappingsByListID := make(map[uuid.UUID][]malak.ContactListMapping)
+	for _, mapping := range mappings {
+		mappingsByListID[mapping.ListID] = append(mappingsByListID[mapping.ListID], mapping)
+	}
+
+	responseLists := []struct {
+		List     malak.ContactList          "json:\"list,omitempty\" validate:\"required\""
+		Mappings []malak.ContactListMapping "json:\"mappings,omitempty\" validate:\"required\""
+	}{}
+
+	for _, v := range list {
+		responseLists = append(responseLists, struct {
+			List     malak.ContactList          "json:\"list,omitempty\" validate:\"required\""
+			Mappings []malak.ContactListMapping "json:\"mappings,omitempty\" validate:\"required\""
+		}{
+			List:     v,
+			Mappings: mappingsByListID[v.ID],
+		})
+	}
+
 	return fetchContactListsResponse{
-		APIStatus: newAPIStatus(http.StatusCreated, "list was successfully created"),
-		Lists:     list,
+		APIStatus: newAPIStatus(http.StatusOK, "list was successfully retrieved"),
+		Lists:     responseLists,
 	}, StatusSuccess
 }
 
@@ -356,8 +381,7 @@ func (c *contactHandler) deleteContactList(
 }
 
 type addContactToListRequest struct {
-	Reference   malak.Reference
-	ContactList uuid.UUID
+	Reference malak.Reference
 
 	GenericRequest
 }
@@ -365,10 +389,6 @@ type addContactToListRequest struct {
 func (c *addContactToListRequest) Validate() error {
 	if hermes.IsStringEmpty(c.Reference.String()) {
 		return errors.New("please provide the reference of the contact")
-	}
-
-	if c.ContactList == uuid.Nil {
-		return errors.New("please provide the list to add the user to")
 	}
 
 	return nil
@@ -410,8 +430,8 @@ func (c *contactHandler) addUserToContactList(
 		return newAPIStatus(http.StatusBadRequest, err.Error()), StatusFailed
 	}
 
-	logger = logger.With(zap.String("reference", req.Reference.String()),
-		zap.String("contact_list_id", req.ContactList.String()))
+	logger = logger.With(zap.String("contact_id", req.Reference.String()),
+		zap.String("list_reference", reference))
 
 	contact, err := c.contactRepo.Get(ctx, malak.FetchContactOptions{
 		Reference: req.Reference,
@@ -446,6 +466,7 @@ func (c *contactHandler) addUserToContactList(
 		Reference: c.referenceGenerator.Generate(malak.EntityTypeListEmail),
 		ListID:    list.ID,
 		ContactID: contact.ID,
+		CreatedBy: getUserFromContext(ctx).ID,
 	}
 
 	if err := c.contactListRepo.Add(ctx, mapping); err != nil {
@@ -454,5 +475,5 @@ func (c *contactHandler) addUserToContactList(
 			StatusFailed
 	}
 
-	return newAPIStatus(http.StatusCreated, "list was successfully deleted"), StatusSuccess
+	return newAPIStatus(http.StatusCreated, "list was successfully updated with contact"), StatusSuccess
 }

--- a/server/contact_test.go
+++ b/server/contact_test.go
@@ -439,7 +439,7 @@ func generateFetchContactListsTestTable() []struct {
 			name: "unknown error",
 			mockFn: func(contactListRepo *malak_mocks.MockContactListRepository) {
 				contactListRepo.EXPECT().List(gomock.Any(), gomock.Any()).
-					Return(nil, errors.New("unknown error"))
+					Return(nil, nil, errors.New("unknown error"))
 			},
 			expectedStatusCode: http.StatusInternalServerError,
 		},
@@ -447,9 +447,9 @@ func generateFetchContactListsTestTable() []struct {
 			name: "success",
 			mockFn: func(contactListRepo *malak_mocks.MockContactListRepository) {
 				contactListRepo.EXPECT().List(gomock.Any(), gomock.Any()).
-					Return([]malak.ContactList{}, nil)
+					Return([]malak.ContactList{}, []malak.ContactListMappingWithContact{}, nil)
 			},
-			expectedStatusCode: http.StatusCreated,
+			expectedStatusCode: http.StatusOK,
 		},
 	}
 }

--- a/server/contact_test.go
+++ b/server/contact_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/ayinke-llc/malak"
 	malak_mocks "github.com/ayinke-llc/malak/mocks"
 	"github.com/go-chi/chi/v5"
-	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 )
@@ -268,16 +267,6 @@ func generateAddUserToContactListTestTable() []struct {
 			req:                addContactToListRequest{},
 		},
 		{
-			name: "reference provided but no list id",
-			mockFn: func(contactListRepo *malak_mocks.MockContactListRepository, contactRepo *malak_mocks.MockContactRepository) {
-
-			},
-			expectedStatusCode: http.StatusBadRequest,
-			req: addContactToListRequest{
-				Reference: "oops",
-			},
-		},
-		{
 			name: "contact not found",
 			mockFn: func(contactListRepo *malak_mocks.MockContactListRepository, contactRepo *malak_mocks.MockContactRepository) {
 				contactRepo.EXPECT().
@@ -287,8 +276,7 @@ func generateAddUserToContactListTestTable() []struct {
 			},
 			expectedStatusCode: http.StatusNotFound,
 			req: addContactToListRequest{
-				Reference:   "oops",
-				ContactList: uuid.New(),
+				Reference: "oops",
 			},
 		},
 		{
@@ -301,8 +289,7 @@ func generateAddUserToContactListTestTable() []struct {
 			},
 			expectedStatusCode: http.StatusInternalServerError,
 			req: addContactToListRequest{
-				Reference:   "oops",
-				ContactList: uuid.New(),
+				Reference: "oops",
 			},
 		},
 		{
@@ -319,8 +306,7 @@ func generateAddUserToContactListTestTable() []struct {
 			},
 			expectedStatusCode: http.StatusNotFound,
 			req: addContactToListRequest{
-				Reference:   "oops",
-				ContactList: uuid.New(),
+				Reference: "oops",
 			},
 		},
 		{
@@ -337,8 +323,7 @@ func generateAddUserToContactListTestTable() []struct {
 			},
 			expectedStatusCode: http.StatusInternalServerError,
 			req: addContactToListRequest{
-				Reference:   "oops",
-				ContactList: uuid.New(),
+				Reference: "oops",
 			},
 		},
 		{
@@ -359,8 +344,7 @@ func generateAddUserToContactListTestTable() []struct {
 			},
 			expectedStatusCode: http.StatusInternalServerError,
 			req: addContactToListRequest{
-				Reference:   "oops",
-				ContactList: uuid.New(),
+				Reference: "oops",
 			},
 		},
 		{
@@ -382,8 +366,7 @@ func generateAddUserToContactListTestTable() []struct {
 			},
 			expectedStatusCode: http.StatusCreated,
 			req: addContactToListRequest{
-				Reference:   "oops",
-				ContactList: uuid.New(),
+				Reference: "oops",
 			},
 		},
 	}

--- a/server/response.go
+++ b/server/response.go
@@ -88,5 +88,8 @@ type fetchContactListResponse struct {
 
 type fetchContactListsResponse struct {
 	APIStatus
-	Lists []malak.ContactList `json:"lists,omitempty"`
+	Lists []struct {
+		List     malak.ContactList          `json:"list,omitempty" validate:"required"`
+		Mappings []malak.ContactListMapping `json:"mappings,omitempty" validate:"required"`
+	} `json:"lists,omitempty" validate:"required"`
 }

--- a/server/response.go
+++ b/server/response.go
@@ -89,7 +89,7 @@ type fetchContactListResponse struct {
 type fetchContactListsResponse struct {
 	APIStatus
 	Lists []struct {
-		List     malak.ContactList          `json:"list,omitempty" validate:"required"`
-		Mappings []malak.ContactListMapping `json:"mappings,omitempty" validate:"required"`
+		List     malak.ContactList                     `json:"list,omitempty" validate:"required"`
+		Mappings []malak.ContactListMappingWithContact `json:"mappings,omitempty" validate:"required"`
 	} `json:"lists,omitempty" validate:"required"`
 }

--- a/server/testdata/TestContactHandler_AddUserToContactList/added_contact_to_list.golden
+++ b/server/testdata/TestContactHandler_AddUserToContactList/added_contact_to_list.golden
@@ -1,1 +1,1 @@
-{"message":"list was successfully deleted"}
+{"message":"list was successfully updated with contact"}

--- a/server/testdata/TestContactHandler_FetchContactLists/success.golden
+++ b/server/testdata/TestContactHandler_FetchContactLists/success.golden
@@ -1,1 +1,1 @@
-{"message":"list was successfully created"}
+{"message":"list was successfully retrieved"}

--- a/swagger/docs.go
+++ b/swagger/docs.go
@@ -1198,6 +1198,27 @@ const docTemplate = `{
                 }
             }
         },
+        "malak.ContactListMappingWithContact": {
+            "type": "object",
+            "properties": {
+                "contact_id": {
+                    "type": "string"
+                },
+                "email": {
+                    "description": "Contact fields",
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "list_id": {
+                    "type": "string"
+                },
+                "reference": {
+                    "type": "string"
+                }
+            }
+        },
         "malak.CustomContactMetadata": {
             "type": "object",
             "additionalProperties": {
@@ -1407,9 +1428,6 @@ const docTemplate = `{
         "server.addContactToListRequest": {
             "type": "object",
             "properties": {
-                "contactList": {
-                    "type": "string"
-                },
                 "reference": {
                     "type": "string"
                 }
@@ -1568,7 +1586,7 @@ const docTemplate = `{
                             "mappings": {
                                 "type": "array",
                                 "items": {
-                                    "$ref": "#/definitions/malak.ContactListMapping"
+                                    "$ref": "#/definitions/malak.ContactListMappingWithContact"
                                 }
                             }
                         }

--- a/swagger/docs.go
+++ b/swagger/docs.go
@@ -152,6 +152,14 @@ const docTemplate = `{
                 ],
                 "summary": "List all created contact lists",
                 "operationId": "fetchContactLists",
+                "parameters": [
+                    {
+                        "type": "boolean",
+                        "description": "show emails inside the list",
+                        "name": "include_emails",
+                        "in": "query"
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "OK",
@@ -1541,13 +1549,29 @@ const docTemplate = `{
         "server.fetchContactListsResponse": {
             "type": "object",
             "required": [
+                "lists",
                 "message"
             ],
             "properties": {
                 "lists": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/malak.ContactList"
+                        "type": "object",
+                        "required": [
+                            "list",
+                            "mappings"
+                        ],
+                        "properties": {
+                            "list": {
+                                "$ref": "#/definitions/malak.ContactList"
+                            },
+                            "mappings": {
+                                "type": "array",
+                                "items": {
+                                    "$ref": "#/definitions/malak.ContactListMapping"
+                                }
+                            }
+                        }
                     }
                 },
                 "message": {

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -133,6 +133,27 @@
 				},
 				"type": "object"
 			},
+			"malak.ContactListMappingWithContact": {
+				"properties": {
+					"contact_id": {
+						"type": "string"
+					},
+					"email": {
+						"description": "Contact fields",
+						"type": "string"
+					},
+					"id": {
+						"type": "string"
+					},
+					"list_id": {
+						"type": "string"
+					},
+					"reference": {
+						"type": "string"
+					}
+				},
+				"type": "object"
+			},
 			"malak.CustomContactMetadata": {
 				"additionalProperties": {
 					"type": "string"
@@ -341,9 +362,6 @@
 			},
 			"server.addContactToListRequest": {
 				"properties": {
-					"contactList": {
-						"type": "string"
-					},
 					"reference": {
 						"type": "string"
 					}
@@ -491,7 +509,7 @@
 								},
 								"mappings": {
 									"items": {
-										"$ref": "#/components/schemas/malak.ContactListMapping"
+										"$ref": "#/components/schemas/malak.ContactListMappingWithContact"
 									},
 									"type": "array"
 								}

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -485,7 +485,22 @@
 				"properties": {
 					"lists": {
 						"items": {
-							"$ref": "#/components/schemas/malak.ContactList"
+							"properties": {
+								"list": {
+									"$ref": "#/components/schemas/malak.ContactList"
+								},
+								"mappings": {
+									"items": {
+										"$ref": "#/components/schemas/malak.ContactListMapping"
+									},
+									"type": "array"
+								}
+							},
+							"required": [
+								"list",
+								"mappings"
+							],
+							"type": "object"
 						},
 						"type": "array"
 					},
@@ -494,6 +509,7 @@
 					}
 				},
 				"required": [
+					"lists",
 					"message"
 				],
 				"type": "object"
@@ -798,6 +814,16 @@
 		"/contacts/lists": {
 			"get": {
 				"operationId": "fetchContactLists",
+				"parameters": [
+					{
+						"description": "show emails inside the list",
+						"in": "query",
+						"name": "include_emails",
+						"schema": {
+							"type": "boolean"
+						}
+					}
+				],
 				"responses": {
 					"200": {
 						"content": {

--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -91,6 +91,20 @@ components:
         updated_at:
           type: string
       type: object
+    malak.ContactListMappingWithContact:
+      properties:
+        contact_id:
+          type: string
+        email:
+          description: Contact fields
+          type: string
+        id:
+          type: string
+        list_id:
+          type: string
+        reference:
+          type: string
+      type: object
     malak.CustomContactMetadata:
       additionalProperties:
         type: string
@@ -239,8 +253,6 @@ components:
       type: object
     server.addContactToListRequest:
       properties:
-        contactList:
-          type: string
         reference:
           type: string
       type: object
@@ -339,7 +351,7 @@ components:
                 $ref: '#/components/schemas/malak.ContactList'
               mappings:
                 items:
-                  $ref: '#/components/schemas/malak.ContactListMapping'
+                  $ref: '#/components/schemas/malak.ContactListMappingWithContact'
                 type: array
             required:
             - list

--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -334,11 +334,22 @@ components:
       properties:
         lists:
           items:
-            $ref: '#/components/schemas/malak.ContactList'
+            properties:
+              list:
+                $ref: '#/components/schemas/malak.ContactList'
+              mappings:
+                items:
+                  $ref: '#/components/schemas/malak.ContactListMapping'
+                type: array
+            required:
+            - list
+            - mappings
+            type: object
           type: array
         message:
           type: string
       required:
+      - lists
       - message
       type: object
     server.fetchContactResponse:
@@ -534,6 +545,12 @@ paths:
   /contacts/lists:
     get:
       operationId: fetchContactLists
+      parameters:
+      - description: show emails inside the list
+        in: query
+        name: include_emails
+        schema:
+          type: boolean
       responses:
         "200":
           content:


### PR DESCRIPTION
This is needed for the updates page when sending to select lists and profile the input wit the emails from the list.

This PR also fixes a weird REST API syntax introduced in #106 